### PR TITLE
Updated pushrocks to version 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/pushrocks/gulp-bootstrap",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "pushrocks": "1.0.4",
+    "pushrocks": "1.0.5",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
:rocket:

pushrocks just published version 1.0.5, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 1 commits (ahead by 1, behind by 0).

- [25d6417](https://github.com/pushrocks/pushrocks/commit/25d641703f358358280f46aaebe32be1ca1745b5): 1.0.5

See the [full diff](https://github.com/pushrocks/pushrocks/compare/30867da714a20ecd78b0dedf60dad1456af2885d...25d641703f358358280f46aaebe32be1ca1745b5).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>