### PR TITLE
Updated pushrocks to version 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/pushrocks/gulp-bootstrap",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "pushrocks": "1.0.5",
+    "pushrocks": "1.0.6",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
:rocket:

pushrocks just published version 1.0.6, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [fb55cf0](https://github.com/pushrocks/pushrocks/commit/fb55cf0a76cd15b77fda5487eb9aa80d570930a6): 1.0.6
- [59ce086](https://github.com/pushrocks/pushrocks/commit/59ce08628fcdc42dc83bd100779a44e7af509b6e): added smarcli

See the [full diff](https://github.com/pushrocks/pushrocks/compare/25d641703f358358280f46aaebe32be1ca1745b5...fb55cf0a76cd15b77fda5487eb9aa80d570930a6).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>